### PR TITLE
Improve documentation with module references

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ python scripts/run_pipeline.py --url <YOUTUBE_URL> --duration 30 --output custom
 
 The pipeline consists of five main modules:
 
-1. **Downloader**: Extracts audio from YouTube videos using yt-dlp
-2. **Transcriber**: Converts audio to text using OpenAI's Whisper API
-3. **Scene Splitter**: Chunks transcript and generates image prompts using GPT-4o-mini
-4. **Image Generator**: Creates images from prompts using Stability AI
-5. **Video Composer**: Assembles the final video using MoviePy and FFmpeg
+1. **Downloader** – [`downloader.py`](podcast_to_reels/downloader/downloader.py)
+2. **Transcriber** – [`transcriber.py`](podcast_to_reels/transcriber/transcriber.py)
+3. **Scene Splitter** – [`scene_splitter.py`](podcast_to_reels/scene_splitter/scene_splitter.py)
+4. **Image Generator** – [`image_generator.py`](podcast_to_reels/image_generator/image_generator.py)
+5. **Video Composer** – [`video_composer.py`](podcast_to_reels/video_composer/video_composer.py)
 
-![Architecture Diagram](docs/architecture_diagram.png)
+For a full diagram of how these components interact, see the [Architecture Diagram](docs/architecture_diagram.md).  Additional details for each module are provided in [Modules Overview](docs/modules_overview.md).
 
 ## Development
 

--- a/docs/architecture_diagram.md
+++ b/docs/architecture_diagram.md
@@ -1,3 +1,7 @@
+# Architecture Diagram
+
+This diagram illustrates how the major modules interact.  For a textual explanation, see the [Modules Overview](modules_overview.md) and the [README](../README.md).
+
 ```mermaid
 graph TD
     subgraph "Podcast-to-Reels Pipeline"

--- a/docs/modules_overview.md
+++ b/docs/modules_overview.md
@@ -1,0 +1,59 @@
+# Modules Overview
+
+This document describes each pipeline component and cross-references the source code and unit tests.
+
+## Pipeline Modules
+
+1. **Downloader**
+   - Source: [`podcast_to_reels/downloader/downloader.py`](../podcast_to_reels/downloader/downloader.py)
+   - Tests: [`tests/test_downloader.py`](../tests/test_downloader.py)
+   - Responsible for fetching audio from a YouTube URL using `yt-dlp` and trimming long videos with FFmpeg.
+
+2. **Transcriber**
+   - Source: [`podcast_to_reels/transcriber/transcriber.py`](../podcast_to_reels/transcriber/transcriber.py)
+   - Tests: [`tests/test_transcriber.py`](../tests/test_transcriber.py)
+   - Uses the OpenAI Whisper API to convert audio to text.
+
+3. **Scene Splitter**
+   - Source: [`podcast_to_reels/scene_splitter/scene_splitter.py`](../podcast_to_reels/scene_splitter/scene_splitter.py)
+   - Tests: [`tests/test_scene_splitter.py`](../tests/test_scene_splitter.py)
+   - Breaks the transcript into scenes and generates image prompts using GPT‑4o-mini.
+
+4. **Image Generator**
+   - Source: [`podcast_to_reels/image_generator/image_generator.py`](../podcast_to_reels/image_generator/image_generator.py)
+   - Tests: [`tests/test_image_generator.py`](../tests/test_image_generator.py)
+   - Calls the Stability AI API to turn prompts into images.
+
+5. **Video Composer**
+   - Source: [`podcast_to_reels/video_composer/video_composer.py`](../podcast_to_reels/video_composer/video_composer.py)
+   - Tests: [`tests/test_video_composer.py`](../tests/test_video_composer.py)
+   - Combines the generated images and audio clips into a final MP4 video.
+
+## Module/Test Relationships
+
+```mermaid
+graph TD
+    subgraph Pipeline
+        D[Downloader]
+        T[Transcriber]
+        S[Scene Splitter]
+        I[Image Generator]
+        V[Video Composer]
+    end
+
+    subgraph Tests
+        TD[test_downloader.py]
+        TT[test_transcriber.py]
+        TS[test_scene_splitter.py]
+        TI[test_image_generator.py]
+        TV[test_video_composer.py]
+    end
+
+    D --> TD
+    T --> TT
+    S --> TS
+    I --> TI
+    V --> TV
+```
+
+Refer back to the [README](../README.md) for installation and usage instructions.


### PR DESCRIPTION
## Summary
- cross-reference source modules in README
- add a detailed modules overview document with a mermaid chart
- reference modules overview from architecture diagram

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: moviepy.editor)*


------
https://chatgpt.com/codex/tasks/task_e_6841decd23b88322a07d909432b41f20