### PR TITLE
Add pyproject and update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ For a full diagram of how these components interact, see the [Architecture Diagr
 
 ### Running Tests
 
+Install the project in editable mode so that the `podcast_to_reels` package is
+available on your Python path:
+
+```bash
+pip install -e .
+```
+
 ```bash
 # Run all tests
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "podcast_to_reels"
+version = "0.1.0"
+description = "Automated pipeline to convert YouTube science podcasts into video reels"
+readme = "README.md"
+authors = [{name = "Your Name", email = "you@example.com"}]
+requires-python = ">=3.11"
+
+# Dependencies from requirements.txt
+# These may be pinned to mimic requirements
+
+dependencies = [
+    "yt-dlp>=2023.0.0",
+    "openai>=1.0.0",
+    "stability-sdk>=0.8.0",
+    "moviepy>=1.0.3,<2.0",
+    "ffmpeg-python>=0.2.0",
+    "python-dotenv>=1.0.0",
+    "requests>=2.28.0",
+    "pillow>=9.0.0",
+    "numpy>=1.22.0",
+    "tqdm>=4.64.0"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+


### PR DESCRIPTION
## Summary
- add pyproject.toml for editable installs
- document package installation in README's test section

## Testing
- `pip install -e .[test]`
- `pytest` *(fails: 5 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6841e3251b1c8322869b685f37613a20