### PR TITLE
Add start_time support for audio download

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ poetry install
 ### Basic Usage
 
 ```bash
-python scripts/run_pipeline.py --url <YOUTUBE_URL> --duration 60
+python scripts/run_pipeline.py --url <YOUTUBE_URL> --duration 60 --start-time 0
 ```
 
 This will:
@@ -85,7 +85,7 @@ This will:
 ### Advanced Options
 
 ```bash
-python scripts/run_pipeline.py --url <YOUTUBE_URL> --duration 30 --output custom_output.mp4
+python scripts/run_pipeline.py --url <YOUTUBE_URL> --duration 30 --start-time 10 --output custom_output.mp4
 ```
 
 ## Pipeline Architecture

--- a/podcast_to_reels/downloader/downloader.py
+++ b/podcast_to_reels/downloader/downloader.py
@@ -12,13 +12,14 @@ import tempfile
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-def download_audio(url, duration=60, output_dir="output", filename="audio.mp3"):
+def download_audio(url, duration=60, start_time=0, output_dir="output", filename="audio.mp3"):
     """
     Download audio from a YouTube URL and optionally trim it to a specified duration.
     
     Args:
         url (str): YouTube URL to download from
         duration (int): Maximum duration in seconds (default: 60)
+        start_time (int): Starting point in seconds (default: 0)
         output_dir (str): Directory to save the audio file
         filename (str): Name of the output audio file
         
@@ -42,8 +43,8 @@ def download_audio(url, duration=60, output_dir="output", filename="audio.mp3"):
         video_duration = int(subprocess.check_output(duration_cmd, text=True).strip())
         logger.info(f"Video duration: {video_duration} seconds")
         
-        # If video is longer than requested duration, we'll need to trim it
-        needs_trimming = video_duration > duration
+        # Determine if we need to trim based on duration or start time
+        needs_trimming = video_duration > duration or start_time > 0
         
         if needs_trimming:
             # Download to a temporary file first
@@ -63,12 +64,12 @@ def download_audio(url, duration=60, output_dir="output", filename="audio.mp3"):
             subprocess.run(download_cmd, check=True)
             
             # Trim the audio using ffmpeg
-            logger.info(f"Trimming audio to {duration} seconds")
+            logger.info(f"Trimming audio: start at {start_time}s for {duration} seconds")
             trim_cmd = [
                 "ffmpeg",
                 "-i", temp_path,
-                "-ss", "0",  # Start from beginning
-                "-t", str(duration),  # Duration in seconds
+                "-ss", str(start_time),
+                "-t", str(duration),
                 "-c:a", "libmp3lame",
                 "-q:a", "0",  # Best quality
                 "-y",  # Overwrite output file

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -28,10 +28,16 @@ def parse_arguments():
         help="YouTube URL of the podcast"
     )
     parser.add_argument(
-        "--duration", 
-        type=int, 
-        default=60, 
+        "--duration",
+        type=int,
+        default=60,
         help="Duration of the output video in seconds (default: 60)"
+    )
+    parser.add_argument(
+        "--start-time",
+        type=int,
+        default=0,
+        help="Start time of the clip in seconds (default: 0)"
     )
     parser.add_argument(
         "--output", 
@@ -49,7 +55,7 @@ def main():
     print(f"Target duration: {args.duration} seconds")
     
     # Step 1: Download audio from YouTube
-    audio_path = download_audio(args.url, args.duration)
+    audio_path = download_audio(args.url, args.duration, args.start_time)
     print(f"Audio downloaded to: {audio_path}")
     
     # Step 2: Transcribe audio


### PR DESCRIPTION
## Summary
- allow passing `start_time` to audio downloader
- take new argument in `run_pipeline`
- document `--start-time` usage in README

## Testing
- `pip install -e .`
- `pytest -q` *(fails: FileNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841e54f143c832284462551f24c62f4