### PR TITLE
Add Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project provides an end-to-end solution for transforming dialogue-style sci
 - Detailed logging throughout the pipeline
 - Configurable output parameters (duration, resolution, etc.)
 - CI/CD integration via GitHub Actions
+- Optional Flask web interface
 
 ## Requirements
 
@@ -88,6 +89,16 @@ This will:
 python scripts/run_pipeline.py --url <YOUTUBE_URL> --duration 30 --start-time 10 --output custom_output.mp4
 ```
 
+### Web Interface
+
+You can also run the pipeline through a simple web UI powered by Flask. Start the server with:
+
+```bash
+FLASK_APP=web/app.py flask run
+```
+
+Then open `http://localhost:5000` in your browser and submit the YouTube URL and start/end times. See [Web Interface](docs/web_interface.md) for deployment details.
+
 ## Pipeline Architecture
 
 The pipeline consists of five main modules:
@@ -135,6 +146,8 @@ podcast-to-reels/
 │   └── utils/              # Shared utilities
 ├── scripts/                # Command-line scripts
 │   └── run_pipeline.py     # Main entry point
+├── web/                    # Flask web application
+│   └── templates/          # HTML templates
 ├── tests/                  # Unit tests
 ├── output/                 # Generated artifacts
 ├── docs/                   # Documentation

--- a/docs/web_interface.md
+++ b/docs/web_interface.md
@@ -1,0 +1,26 @@
+# Web Interface
+
+This project includes a small Flask app that runs the entire pipeline from the browser.
+
+## Running Locally
+
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Copy `.env.example` to `.env` and fill in your API keys.
+3. Start the Flask development server
+   ```bash
+   FLASK_APP=web/app.py flask run
+   ```
+4. Open your browser to `http://localhost:5000` and submit a YouTube URL with the start and end times for the clip.
+
+The app will display progress messages and provide a link to download the generated reel when finished.
+
+## Deployment
+
+The web interface can be deployed to any platform that supports Python web applications. Set the start command to run `flask run` and ensure the environment variables from `.env` are configured.
+
+## Directory
+
+Generated files are saved under `output/web/`.

--- a/podcast_to_reels/downloader/downloader.py
+++ b/podcast_to_reels/downloader/downloader.py
@@ -77,8 +77,9 @@ def download_audio(url, duration=60, start_time=0, output_dir="output", filename
             ]
             subprocess.run(trim_cmd, check=True)
             
-            # Clean up temporary file
-            os.unlink(temp_path)
+            # Clean up temporary file if it exists
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
         else:
             # Download directly to output path
             download_cmd = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "requests>=2.28.0",
     "pillow>=9.0.0",
     "numpy>=1.22.0",
-    "tqdm>=4.64.0"
+    "tqdm>=4.64.0",
+    "Flask>=2.2.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests>=2.28.0
 pillow>=9.0.0
 numpy>=1.22.0
 tqdm>=4.64.0
+Flask>=2.2.0

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,44 @@
+from flask import Flask, render_template, request
+import os
+from podcast_to_reels.downloader import download_audio
+from podcast_to_reels.transcriber import transcribe_audio
+from podcast_to_reels.scene_splitter import split_scenes
+from podcast_to_reels.image_generator import generate_images
+from podcast_to_reels.video_composer import compose_video
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        url = request.form.get('url', '').strip()
+        start_time = int(request.form.get('start_time', 0))
+        end_time = int(request.form.get('end_time', 60))
+        duration = max(0, end_time - start_time)
+
+        output_dir = os.path.join('output', 'web')
+        os.makedirs(output_dir, exist_ok=True)
+
+        messages = []
+        audio_path = download_audio(url, duration=duration, start_time=start_time, output_dir=output_dir)
+        messages.append(f"Audio downloaded to: {audio_path}")
+
+        transcript_path = transcribe_audio(audio_path, output_dir=output_dir)
+        messages.append(f"Transcript saved to: {transcript_path}")
+
+        scenes = split_scenes(transcript_path, output_dir=output_dir)
+        messages.append(f"Generated {len(scenes)} scenes")
+
+        images_dir = os.path.join(output_dir, 'images')
+        image_paths = generate_images(scenes, output_dir=images_dir)
+        messages.append(f"Generated {len(image_paths)} images")
+
+        reel_path = compose_video(audio_path, image_paths, scenes, os.path.join(output_dir, 'reel.mp4'))
+        messages.append(f"Video reel created at: {reel_path}")
+
+        return render_template('result.html', messages=messages, reel_path=reel_path)
+
+    return render_template('form.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/web/templates/form.html
+++ b/web/templates/form.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+    <title>Podcast to Reels</title>
+</head>
+<body>
+    <h1>Podcast to Reels</h1>
+    <form method="post">
+        <label>YouTube URL:<br>
+            <input type="text" name="url" required>
+        </label><br><br>
+        <label>Start Time (seconds):<br>
+            <input type="number" name="start_time" value="0">
+        </label><br><br>
+        <label>End Time (seconds):<br>
+            <input type="number" name="end_time" value="60">
+        </label><br><br>
+        <button type="submit">Create Reel</button>
+    </form>
+</body>
+</html>

--- a/web/templates/result.html
+++ b/web/templates/result.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+    <title>Podcast to Reels - Result</title>
+</head>
+<body>
+    <h1>Result</h1>
+    <ul>
+        {% for msg in messages %}
+        <li>{{ msg }}</li>
+        {% endfor %}
+    </ul>
+    <p><a href="/{{ reel_path }}">Download Video</a></p>
+    <p><a href="/">Back</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple Flask app for running the pipeline via web form
- document how to run the web interface
- mention optional web interface in README and project structure
- include Flask dependency
- avoid crash in `download_audio` when temp file is mocked

## Testing
- `pip install -e .`
- `pytest -q` *(fails: test_scene_splitter_api_error, test_transcribe_audio_success, test_video_composer tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6d3b59c83229b0d6447cb8e6224